### PR TITLE
Fix to first gif.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SmearFrame
 "Smear frame" material effect for Unreal Engine 4.12
 
-![Smear Frame effect](http://broad-strokes.com/media/smear3.gif "UE4 Smear Frame effect")
+![Smear Frame effect](http://i.giphy.com/l46CcnrPYQsJ0ejw4.gif "UE4 Smear Frame effect")
 
 ## What is this?
 This is an Unreal Engine 4 project containing a simple implementation of a "smear frame" effect, as recently popularized by the game Overwatch.


### PR DESCRIPTION
First gif has corruption on it's final frame of animation leading to unstable results in various browsers.

I have downloaded the gif and re-uploaded with the final frame of animation removed which results in no half frames, though the result does lead to a noticeable jump in animation.

Testing results before fix:

iOS - iPhone 6:
Chrome - plays correctly by skipping final frame
Safari - results in final frame being rendered as a "half frame" with white lower half

Desktop Windows 10 64 bit:
Edge - results in final frame being rendered as a "half frame" with blue horizontal line and black lower half
Internet Explorer 11 - results in final frame being rendered as a "half frame" with blue horizontal line and black lower half
Firefox - results in final frame being rendered as a "half frame" and black lower half
Chrome - results in gif occasionally ending it's playback loop
